### PR TITLE
edit add schemas - consumer test succeed

### DIFF
--- a/clients/cloud/java/README.md
+++ b/clients/cloud/java/README.md
@@ -6,3 +6,25 @@ Produce messages to and consume messages from a Kafka cluster using the Java Pro
 # Documentation
 
 You can find the documentation and instructions for running this Java example at [https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/java.html](https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/java.html?utm_source=github&utm_medium=demo&utm_campaign=ch.examples_type.community_content.clients-ccloud)
+
+
+
+mvn clean package
+
+## 필드 수정하는법
+/Users/hansohee/dev/confluent_java_examples/examples/clients/cloud/java/target/generated-sources/io/confluent/examples/clients/cloud/DataRecordAvro.java
+
+## 실행하는법
+mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ProducerExample" \
+-Dexec.args="java.config test2"
+
+## 실행하는법
+mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerAvroExample" \
+-Dexec.args="java.config test1"
+
+
+
+
+
+# 참고 
+https://memorynotfound.com/spring-kafka-json-serializer-deserializer-example/

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ConsumerExample.java
@@ -66,7 +66,7 @@ public class ConsumerExample {
         for (ConsumerRecord<String, DataRecord> record : records) {
           String key = record.key();
           DataRecord value = record.value();
-          total_count += value.getCount();
+          total_count += value.getName();
           System.out.printf("Consumed record with key %s and value %s, and updated total count to %d%n", key, value, total_count);
         }
       }

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/ProducerAvroExample.java
@@ -83,7 +83,7 @@ public class ProducerAvroExample {
     final Long numMessages = 10L;
     for (Long i = 0L; i < numMessages; i++) {
       String key = "alice";
-      DataRecordAvro record = new DataRecordAvro(i, "test");
+      DataRecordAvro record = new DataRecordAvro(i);
 
       System.out.printf("Producing record: %s\t%s%n", key, record);
       producer.send(new ProducerRecord<String, DataRecordAvro>(topic, key, record), new Callback() {

--- a/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/model/DataRecord.java
+++ b/clients/cloud/java/src/main/java/io/confluent/examples/clients/cloud/model/DataRecord.java
@@ -1,22 +1,62 @@
 package io.confluent.examples.clients.cloud.model;
 
+// public class DataRecord {
+
+//     Long count;
+
+//     public DataRecord() {
+//     }
+
+//     public DataRecord(Long count) {
+//         this.count = count;
+//     }
+
+//     public Long getCount() {
+//         return count;
+//     }
+
+//     public String toString() {
+//         return new com.google.gson.Gson().toJson(this);
+//     }
+
+// }
+
+
+
 public class DataRecord {
 
-    Long count;
+    private Long name;
+    private String description;
 
     public DataRecord() {
     }
 
-    public DataRecord(Long count) {
-        this.count = count;
+    public DataRecord(Long name, String description) {
+        this.name = name;
+        this.description = description;
     }
 
-    public Long getCount() {
-        return count;
+    public Long getName() {
+        return name;
     }
 
+    public void setName(Long name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
     public String toString() {
-        return new com.google.gson.Gson().toJson(this);
+        return "Foo{" +
+                "name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                '}';
     }
-
 }


### PR DESCRIPTION
**string type의 schema 를 추가**하였습니다.

컨슈머 테스트 시 성공하였습니다.

`mvn exec:java -Dexec.mainClass="io.confluent.examples.clients.cloud.ConsumerExample" \
-Dexec.args="java.config test2"`

참고링크: https://memorynotfound.com/spring-kafka-json-serializer-deserializer-example/