### PR TITLE
edit data record avro - schema registry

### DIFF
--- a/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro.avsc
+++ b/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro.avsc
@@ -1,11 +1,23 @@
 {
-  "fields": 
-    [{
-      "name": "count",
-      "type": "long"
+  "connect.version": 1,
+  "fields": [
+    {
+      "default": null,
+      "name": "MessageData",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "AttributesMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
     }
   ],
-  "name": "DataRecordAvro",
-  "namespace": "io.confluent.examples.clients.cloud",
+  "name": "ConnectDefault",
+  "namespace": "io.confluent.connect.avro",
   "type": "record"
 }

--- a/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro2a.avsc
+++ b/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro2a.avsc
@@ -1,8 +1,23 @@
-{"namespace": "io.confluent.examples.clients.cloud",
- "type": "record",
- "name": "DataRecordAvro",
- "fields": [
-     {"name": "count", "type": "long"},
-     {"name": "region", "type": "string"}
- ]
+{
+  "connect.version": 1,
+  "fields": [
+    {
+      "default": null,
+      "name": "MessageData",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "AttributesMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
+    }
+  ],
+  "name": "ConnectDefault",
+  "namespace": "io.confluent.connect.avro",
+  "type": "record"
 }

--- a/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro2b.avsc
+++ b/clients/cloud/java/src/main/resources/avro/io/confluent/examples/clients/cloud/DataRecordAvro2b.avsc
@@ -1,8 +1,23 @@
-{"namespace": "io.confluent.examples.clients.cloud",
- "type": "record",
- "name": "DataRecordAvro",
- "fields": [
-     {"name": "count", "type": "long"},
-     {"name": "region", "type": "string", "default": ""}
- ]
+{
+  "connect.version": 1,
+  "fields": [
+    {
+      "default": null,
+      "name": "MessageData",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "AttributesMap",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
+    }
+  ],
+  "name": "ConnectDefault",
+  "namespace": "io.confluent.connect.avro",
+  "type": "record"
 }


### PR DESCRIPTION
avro 로 토픽을 받아오기 위해, schema registry 를 설정합니다.
test 결과 이상 없습니다.

참고문서: https://www.confluent.io/blog/avro-kafka-data/?utm_medium=sem&utm_source=google&utm_campaign=ch.sem_br.brand_tp.prs_tgt.confluent-brand_mt.mbm_rgn.apac_lng.eng_dv.all_con.confluent-avro&utm_term=%2Bconfluent%20%2Bavro&creative=&device=c&placement=&gclid=CjwKCAjw0a-SBhBkEiwApljU0hxlqbNGl96UI6Vt7hnX2uqhfzcV1jQ_ZJwiCytr9FCvrvYqOqJbJxoCL3gQAvD_BwE